### PR TITLE
Add GoogleMaps variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,9 @@ showLocation({
     longitude: -77.0387185,
     sourceLatitude: -8.0870631,  // optional
     sourceLongitude: -34.8941619,  // not optional if sourceLatitude is specified
-    title: 'The White House'  // optional
+    title: 'The White House',  // optional
+    googleForceLatLon: false,  // optionally force GoogleMaps to use the latlon for the query instead of the title
+    googlePlaceId: 'ChIJGVtI4by3t4kRr51d_Qm_x58',  // optionally specify the google-place-id
     // app: 'uber'  // optionally specify specific app to use
 })
 ```

--- a/index.js
+++ b/index.js
@@ -140,6 +140,12 @@ export async function showLocation(options) {
   if ('title' in options && options.title && typeof options.title !== 'string') {
     throw new MapsException('Option `title` should be of type `string`.')
   }
+  if ('googleForceLatLon' in options && options.googleForceLatLon && typeof options.googleForceLatLon !== 'boolean') {
+    throw new MapsException('Option `googleForceLatLon` should be of type `boolean`.')
+  }
+  if ('googlePlaceId' in options && options.googlePlaceId && typeof options.googlePlaceId !== 'number') {
+    throw new MapsException('Option `googlePlaceId` should be of type `number`.')
+  }
   if ('app' in options && options.app && apps.indexOf(options.app) < 0) {
     throw new MapsException('Option `app` should be undefined, null, or one of the following: "' + apps.join('", "') + '".')
   }
@@ -173,12 +179,16 @@ export async function showLocation(options) {
     case 'apple-maps':
       url = prefixes['apple-maps']
       url = (useSourceDestiny) ? `${url}?saddr=${sourceLatLng}&daddr=${latlng}` : `${url}?ll=${latlng}`
-      url += `&q=${encodedTitle || 'Location'}`
+      url += `&q=${title ? encodedTitle : 'Location'}`
       break
     case 'google-maps':
+      let useTitleForQuery = !options.googleForceLatLon && title
+      let googlePlaceId = options.googlePlaceId ? options.googlePlaceId : null
+
       url = prefixes['google-maps']
-      url += `?q=${encodedTitle || 'Location'}`
+      url += `?q=${useTitleForQuery ? encodedTitle : latlng}`
       url += (isIOS) ? '&api=1' : ''
+      url += (googlePlaceId) ? `&query_place_id=${googlePlaceId}` : '',
       url += (useSourceDestiny) ? `&saddr=${sourceLatLng}&daddr=${latlng}` : `&ll=${latlng}`
       break
     case 'citymapper':


### PR DESCRIPTION
If you specify the title in Google Maps, it is gonna try and search for this. These fixes allow you to force the LatLon as a query, or set a googlePlaceId to make sure you get the correct place.