### PR TITLE
Add address param in apple-maps url to pick actual destination

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,7 +68,7 @@ export async function showLocation (options) {
     case 'apple-maps':
       url = prefixes['apple-maps']
       url = (useSourceDestiny) ? `${url}?saddr=${sourceLatLng}&daddr=${latlng}` : `${url}?ll=${latlng}`
-      url += `&q=${title ? encodedTitle : 'Location'}`
+      url += `&q=${title ? `${encodedTitle}&address=${encodedTitle}` : 'Location'}`
       break
     case 'google-maps':
       let useTitleForQuery = !options.googleForceLatLon && title


### PR DESCRIPTION
Hey @tschoffelen,

We discuss about this [Issue](https://github.com/includable/react-native-map-link/issues/23) while ago and finally i get a chance to fix it.  

Please review it when you get a chance. 

Thank you

**Without param `&address=${encodedTitle}`**

```
Address
Oberlin St
Palo Alto CA 94306
United States
```

![without address encodedtitle](https://user-images.githubusercontent.com/38050556/46454826-17347580-c75d-11e8-83c0-a922dcb30395.gif)

**With param `&address=${encodedTitle}`**

```
Address
2351 Oberlin St
Palo Alto CA 94306
United States
```

![with address encodedtitle](https://user-images.githubusercontent.com/38050556/46454945-932ebd80-c75d-11e8-8149-dacbb4c9b7d0.gif)

