### PR TITLE
Correct Type for Options.googlePlaceId

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,7 +7,7 @@ interface Options {
     sourceLatitude?: number
     sourceLongitude?: number
     googleForceLatLon?: boolean
-    googlePlaceId?: number
+    googlePlaceId?: string
     title?: string
     app?: string
     dialogTitle?: string
@@ -19,7 +19,7 @@ interface Options {
 interface PopupStyleProp {
     container?: StyleProp<ViewStyle>,
     itemContainer?: StyleProp<ViewStyle>,
-    image?: StyleProp<ImageStyle>, 
+    image?: StyleProp<ImageStyle>,
     itemText?: StyleProp<TextStyle>,
     headerContainer?: StyleProp<ViewStyle>,
     titleText?: StyleProp<TextStyle>,


### PR DESCRIPTION
Global type for `googlePlaceId` in interface `Options` was `number`. Should be `string`.