### PR TITLE
Bugfix - Example app boilerplate 

### DIFF
--- a/example/App.js
+++ b/example/App.js
@@ -1,5 +1,5 @@
 import React, {Component} from 'react';
-import {Button, StyleSheet, View, Image, Text} from 'react-native';
+import {Button, StyleSheet, View, Image, Text, Pressable} from 'react-native';
 
 import {Popup, showLocation, getApps} from 'react-native-map-link';
 

--- a/example/App.js
+++ b/example/App.js
@@ -31,7 +31,7 @@ export default class App extends Component {
 
   async componentDidMount(){
     const apps = await getApps(options)
-    this.setState(prevState, () => ({...prevState, apps}))
+    this.setState((prevState) => ({...prevState, apps}))
   }
 
   render() {


### PR DESCRIPTION
- [x] Missing Pressable import.
- [x] prevState is set as the first parameter, it should be inside the arrow function parameter otherwise it would get a reference error.