### PR TITLE
Added option to ignore lat & lon for Apple Maps so that only the title is used.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -49,6 +49,7 @@ interface Options extends SharedOptions {
   /** optional, true will always add Google Maps to iOS and open in Safari, even if app is not installed (default: false) */
   alwaysIncludeGoogle?: boolean;
   googleForceLatLon?: boolean;
+  appleIgnoreLatLon?: boolean;
   googlePlaceId?: string;
   title?: string;
   /** optionally specify specific app to use */

--- a/src/index.js
+++ b/src/index.js
@@ -130,7 +130,8 @@ export async function showLocation(options) {
       } else if (!options.appleIgnoreLatLon) {
         url = `${url}?ll=${latlng}`
       }
-      url += `&q=${title ? encodedTitle : 'Location'}`;
+      url += useSourceDestiny || !options.appleIgnoreLatLon ? '&' : '?'
+      url += `q=${title ? encodedTitle : 'Location'}`;
       url += appleDirectionMode ? `&dirflg=${appleDirectionMode}` : '';
       break;
     case 'google-maps':

--- a/src/index.js
+++ b/src/index.js
@@ -125,9 +125,11 @@ export async function showLocation(options) {
     case 'apple-maps':
       const appleDirectionMode = getDirectionsModeAppleMaps();
       url = prefixes['apple-maps'];
-      url = useSourceDestiny
-        ? `${url}?saddr=${sourceLatLng}&daddr=${latlng}`
-        : `${url}?ll=${latlng}`;
+      if (useSourceDestiny) {
+        url = `${url}?saddr=${sourceLatLng}&daddr=${latlng}`
+      } else if (!options.appleIgnoreLatLon) {
+        url = `${url}?ll=${latlng}`
+      }
       url += `&q=${title ? encodedTitle : 'Location'}`;
       url += appleDirectionMode ? `&dirflg=${appleDirectionMode}` : '';
       break;

--- a/src/index.js
+++ b/src/index.js
@@ -126,11 +126,11 @@ export async function showLocation(options) {
       const appleDirectionMode = getDirectionsModeAppleMaps();
       url = prefixes['apple-maps'];
       if (useSourceDestiny) {
-        url = `${url}?saddr=${sourceLatLng}&daddr=${latlng}`
+        url = `${url}?saddr=${sourceLatLng}&daddr=${latlng}`;
       } else if (!options.appleIgnoreLatLon) {
-        url = `${url}?ll=${latlng}`
+        url = `${url}?ll=${latlng}`;
       }
-      url += useSourceDestiny || !options.appleIgnoreLatLon ? '&' : '?'
+      url += useSourceDestiny || !options.appleIgnoreLatLon ? '&' : '?';
       url += `q=${title ? encodedTitle : 'Location'}`;
       url += appleDirectionMode ? `&dirflg=${appleDirectionMode}` : '';
       break;

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -63,6 +63,19 @@ describe('showLocation', () => {
       );
     });
 
+    it('opens with correct url if source is not provided, and has title', () => {
+      verifyThatSettingsLeadToUrl(
+        {
+          latitude,
+          longitude,
+          appleIgnoreLatLon: true,
+          title: 'Taco Bell',
+          app: 'apple-maps',
+        },
+        'maps://?q=Taco%20Bell',
+      );
+    });
+
     it('opens with correct url if source is provided', () => {
       verifyThatSettingsLeadToUrl(
         {


### PR DESCRIPTION
Allows for behavior similar to googleForceLatLon for apple maps.

My thought was that doing the same thing as google maps such as appleForceLatLon was that it would be a breaking change and seemed less ideal than simply adding the option to ignore the lat/lon when the user sets this option to true.