### PR TITLE
fix: avoid parsing undefined source location

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -43,7 +43,7 @@ export async function showLocation(options) {
   let sourceLng;
   let sourceLatLng;
 
-  if ('sourceLatitude' in options && 'sourceLongitude' in options) {
+  if (options.sourceLatitude !== undefined && options.sourceLongitude !== undefined) {
     useSourceDestiny = true;
     sourceLat = parseFloat(options.sourceLatitude);
     sourceLng = parseFloat(options.sourceLongitude);

--- a/src/index.js
+++ b/src/index.js
@@ -43,7 +43,7 @@ export async function showLocation(options) {
   let sourceLng;
   let sourceLatLng;
 
-  if (options.sourceLatitude !== undefined && options.sourceLongitude !== undefined) {
+  if (options.sourceLatitude != null && options.sourceLongitude != null) {
     useSourceDestiny = true;
     sourceLat = parseFloat(options.sourceLatitude);
     sourceLng = parseFloat(options.sourceLongitude);

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -54,6 +54,32 @@ describe('showLocation', () => {
       );
     });
 
+    it('opens with correct url if source is set to undefined', () => {
+      verifyThatSettingsLeadToUrl(
+        {
+          latitude,
+          longitude,
+          sourceLatitude: undefined,
+          sourceLongitude: undefined,
+          app: 'apple-maps',
+        },
+        'maps://?ll=123,234&q=Location',
+      );
+    });
+
+    it('opens with correct url if source is set to 0,0', () => {
+      verifyThatSettingsLeadToUrl(
+        {
+          latitude,
+          longitude,
+          sourceLatitude: 0,
+          sourceLongitude: 0,
+          app: 'apple-maps',
+        },
+        'maps://?saddr=0,0&daddr=123,234&q=Location',
+      );
+    });
+
     it('opens with correct url if source is not provided, and has title', () => {
       verifyThatSettingsLeadToUrl(
         {
@@ -90,6 +116,32 @@ describe('showLocation', () => {
           app: 'google-maps',
         },
         'https://www.google.com/maps/search/?api=1&query=123,234',
+      );
+    });
+
+    it('opens with correct url if source is set to undefined', () => {
+      verifyThatSettingsLeadToUrl(
+        {
+          latitude,
+          longitude,
+          sourceLatitude: undefined,
+          sourceLongitude: undefined,
+          app: 'google-maps',
+        },
+        'https://www.google.com/maps/search/?api=1&query=123,234',
+      );
+    });
+
+    it('opens with correct url if source is set to 0,0', () => {
+      verifyThatSettingsLeadToUrl(
+        {
+          latitude,
+          longitude,
+          sourceLatitude: 0,
+          sourceLongitude: 0,
+          app: 'google-maps',
+        },
+        'https://www.google.com/maps/dir/?api=1&origin=0,0&destination=123,234',
       );
     });
 

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -76,7 +76,7 @@ describe('showLocation', () => {
           sourceLongitude: 0,
           app: 'apple-maps',
         },
-        'maps://?saddr=0,0&daddr=123,234&q=Location',
+        'maps://?daddr=123,234&saddr=0,0&q=Location',
       );
     });
 


### PR DESCRIPTION
Currently, setting `sourceLatitude` and `sourceLongitude` to `undefined` will make `sourceLatLng` to be `'NaN,NaN'`