### PR TITLE
fix: allow directions mode without source in apple map

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -125,12 +125,13 @@ export async function showLocation(options) {
     case 'apple-maps':
       const appleDirectionMode = getDirectionsModeAppleMaps();
       url = prefixes['apple-maps'];
-      if (useSourceDestiny) {
-        url = `${url}?saddr=${sourceLatLng}&daddr=${latlng}`;
+      if (useSourceDestiny || options.directionsMode) {
+        url = `${url}?daddr=${latlng}`;
+        url += sourceLatLng ? `&saddr=${sourceLatLng}` : '';
       } else if (!options.appleIgnoreLatLon) {
         url = `${url}?ll=${latlng}`;
       }
-      url += useSourceDestiny || !options.appleIgnoreLatLon ? '&' : '?';
+      url += useSourceDestiny || options.directionsMode || !options.appleIgnoreLatLon ? '&' : '?';
       url += `q=${title ? encodedTitle : 'Location'}`;
       url += appleDirectionMode ? `&dirflg=${appleDirectionMode}` : '';
       break;

--- a/src/index.js
+++ b/src/index.js
@@ -131,7 +131,10 @@ export async function showLocation(options) {
       } else if (!options.appleIgnoreLatLon) {
         url = `${url}?ll=${latlng}`;
       }
-      url += useSourceDestiny || options.directionsMode || !options.appleIgnoreLatLon ? '&' : '?';
+      url +=
+        useSourceDestiny || options.directionsMode || !options.appleIgnoreLatLon
+          ? '&'
+          : '?';
       url += `q=${title ? encodedTitle : 'Location'}`;
       url += appleDirectionMode ? `&dirflg=${appleDirectionMode}` : '';
       break;

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -67,6 +67,18 @@ describe('showLocation', () => {
       );
     });
 
+    it('opens with correct url if source is not provided, and has directionsMode', () => {
+      verifyThatSettingsLeadToUrl(
+        {
+          latitude,
+          longitude,
+          directionsMode: 'car',
+          app: 'apple-maps',
+        },
+        'maps://?daddr=123,234&q=Location&dirflg=d',
+      );
+    });
+
     it('opens with correct url if source is provided', () => {
       verifyThatSettingsLeadToUrl(
         {
@@ -76,7 +88,7 @@ describe('showLocation', () => {
           sourceLongitude,
           app: 'apple-maps',
         },
-        'maps://?saddr=567,890&daddr=123,234&q=Location',
+        'maps://?daddr=123,234&saddr=567,890&q=Location',
       );
     });
   });
@@ -114,6 +126,18 @@ describe('showLocation', () => {
           app: 'google-maps',
         },
         'https://www.google.com/maps/search/?api=1&query=123,234&query_place_id=ChIJ10bTGLWxEmsRFX2VrdMRW_A',
+      );
+    });
+
+    it('opens with correct url if source is not provided, and has directionsMode', () => {
+      verifyThatSettingsLeadToUrl(
+        {
+          latitude,
+          longitude,
+          directionsMode: 'car',
+          app: 'google-maps',
+        },
+        'https://www.google.com/maps/dir/?api=1&destination=123,234&travelmode=driving',
       );
     });
 


### PR DESCRIPTION
According to the [Apple Map Links Doc](https://developer.apple.com/library/archive/featuredarticles/iPhoneURLScheme_Reference/MapLinks/MapLinks.html), the `saddr` param is not required.

So we should handle `directionsMode` the same way as the Google Maps. Otherwise we could not enter directions mode in Apple maps with user's current location as the starting point.

<img width="1347" alt="image" src="https://github.com/includable/react-native-map-link/assets/18205362/d43327e2-0e23-4f6f-8ae0-ed3923ae2c5a">
