### PR TITLE
fix: Images are added in the build (V3.0.1)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -13,12 +13,15 @@ import {
 export {
   showLocation,
   getApps,
-  Popup,
+  Popup
+};
+
+export type {
   GetAppsResponse,
   MapId,
   SharedOptions,
   MapLinkOptions,
   PopupStyleProp,
   PopupProps,
-  DirectionMode,
+  DirectionMode
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-map-link",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Open the map app of the user's choice with a specific location.",
   "source": "src/index",
   "main": "lib/index.js",
@@ -9,10 +9,11 @@
     "url": "git+https://github.com/includable/react-native-map-link.git"
   },
   "scripts": {
-    "build": "tsc --project tsconfig.build.json",
+    "build": "npm run copy-images && tsc --project tsconfig.build.json",
     "lint": "eslint src --max-warnings=0 && eslint tests --max-warnings=0",
     "release": "semantic-release",
     "test": "jest",
+    "copy-images": "mkdir -p ./lib/images && cp -r ./src/images ./lib",
     "tscheck": "tsc --noEmit"
   },
   "keywords": [


### PR DESCRIPTION
Fixed the error that the images were not found in the build folder
- Added a new step "copy" on the package.json, this will help us so that every time the build is done the images are copied
- Fixed index.ts, should only export type 