### PR TITLE
fix: improve popup default styles

### DIFF
--- a/src/components/popup/Popup.tsx
+++ b/src/components/popup/Popup.tsx
@@ -89,11 +89,12 @@ export const Popup: React.FC<PopupProps> = ({
 
   return (
     <Modal
-      visible={isVisible}
       animationType="slide"
       onRequestClose={() => {
         setIsVisible(false);
       }}
+      transparent={true}
+      visible={isVisible}
       {...modalProps}>
       <View style={[styles.container, style.container]}>
         <View style={[styles.modalView, style.modalView]}>
@@ -124,14 +125,13 @@ export const Popup: React.FC<PopupProps> = ({
 
 const styles = StyleSheet.create({
   container: {
-    backgroundColor: 'white',
-    borderRadius: 10,
-    maxHeight: SCREEN_HEIGHT * 0.6,
+    backgroundColor: 'rgba(255,255,255,0.4)',
     flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
   },
   modalView: {
+    maxHeight: SCREEN_HEIGHT * 0.6,
     margin: 20,
     backgroundColor: 'white',
     borderRadius: 20,


### PR DESCRIPTION
## Description

I'm not sure if the current style is fully tested, but it does not work well in our app.

If this PR is not going to be merged, at least we should have #289 to allow user customizing the modalView style.

FYI, the [example provided by react-native docs](https://reactnative.dev/docs/modal#example) also does not restrict the height and background color of the container:

<img width="419" alt="image" src="https://github.com/includable/react-native-map-link/assets/18205362/63947248-1274-4f37-b865-e912a66fe09e">

## Screenshots

|  Before   | After |
|  ----  | ----  | 
| <img src="https://github.com/includable/react-native-map-link/assets/18205362/3e9e0467-d290-4111-ae2e-f2eac0839e05" width="370" />  | <img src="https://github.com/includable/react-native-map-link/assets/18205362/edfe929c-3a6b-496c-b186-e7dcbd7ec041" width="370" /> |


