### PR TITLE
types: narrow 'ImageSourcePropType' -> 'ImageRequireSource' to support <FastImage>

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,4 @@
-import {Platform} from 'react-native';
+import {Platform, type ImageRequireSource} from 'react-native';
 import type {MapId} from './type';
 
 export const isIOS: boolean = Platform.OS === 'ios';
@@ -76,7 +76,7 @@ export const generateTitles = (
   };
 };
 
-export const icons: Record<string, number> = {
+export const icons: Record<string, ImageRequireSource> = {
   'apple-maps': require('./images/apple-maps.png'),
   'google-maps': require('./images/google-maps.png'),
   citymapper: require('./images/citymapper.png'),

--- a/src/type.ts
+++ b/src/type.ts
@@ -1,4 +1,4 @@
-import type {ImageSourcePropType} from 'react-native';
+import type {ImageRequireSource} from 'react-native';
 
 /** id for map application. this is the id that is passed to the `app` option */
 export type MapId =
@@ -40,7 +40,7 @@ export interface SharedOptions {
 export type GetAppsResponse = {
   id: MapId;
   name: string;
-  icon: ImageSourcePropType;
+  icon: ImageRequireSource;
   /** function to link user to map app */
   open: () => Promise<string | null | undefined>;
 };


### PR DESCRIPTION
**TL;DR** - Narrow icon type to ImageRequireSource (= alias to number, valid as ImageSource).

Internally, icons are numbers (require(...)).
However, they were typed as ImageSourcePropType, which is a union of number | object | object[].

Some libs like [react-native-fast-image](https://github.com/DylanVann/react-native-fast-image) only accept numbers (ImageRequireSource).
This causes an incompatibility, which can easily be solved by using the correct narrower `ImageRequireSource` type for the icons.